### PR TITLE
Add packaging and application service example with connectivity check

### DIFF
--- a/src/DidarTask.Application/Services/AccessInfo.cs
+++ b/src/DidarTask.Application/Services/AccessInfo.cs
@@ -1,0 +1,8 @@
+namespace DidarTask.Application.Services;
+
+/// <summary>
+/// Represents the subscription access information returned by the Packaging service.
+/// </summary>
+/// <param name="SubscriptionLevel">Human readable name of the user's plan.</param>
+/// <param name="AllowedFeatures">Number of features the plan allows.</param>
+public record AccessInfo(string SubscriptionLevel, int AllowedFeatures);

--- a/src/DidarTask.Application/Services/ApplicationService.cs
+++ b/src/DidarTask.Application/Services/ApplicationService.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace DidarTask.Application.Services;
+
+/// <summary>
+/// Represents the business application service which requests access information
+/// from the Packaging service throughout the application.
+/// </summary>
+public class ApplicationService
+{
+    private readonly IPackagingService _packagingService;
+
+    public ApplicationService(IPackagingService packagingService)
+    {
+        _packagingService = packagingService;
+    }
+
+    /// <summary>
+    /// Retrieves the current user's subscription information.
+    /// </summary>
+    public AccessInfo RequestAccessInfo(Guid userId) => _packagingService.GetAccessInfo(userId);
+
+    /// <summary>
+    /// Verifies that the Packaging service can be reached.
+    /// </summary>
+    public bool VerifyPackagingConnection() => _packagingService.Ping();
+}

--- a/src/DidarTask.Application/Services/IPackagingService.cs
+++ b/src/DidarTask.Application/Services/IPackagingService.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace DidarTask.Application.Services;
+
+/// <summary>
+/// Interface for the Packaging service providing subscription information
+/// and a simple connectivity check.
+/// </summary>
+public interface IPackagingService
+{
+    /// <summary>
+    /// Returns access information for a specific user.
+    /// </summary>
+    AccessInfo GetAccessInfo(Guid userId);
+
+    /// <summary>
+    /// Returns true when the Packaging service is reachable.
+    /// </summary>
+    bool Ping();
+}

--- a/src/DidarTask.Application/Services/PackagingService.cs
+++ b/src/DidarTask.Application/Services/PackagingService.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+
+namespace DidarTask.Application.Services;
+
+/// <summary>
+/// Simple in-memory implementation of <see cref="IPackagingService"/>.
+/// In a real-world scenario this would make network requests to another service.
+/// </summary>
+public class PackagingService : IPackagingService
+{
+    private readonly Dictionary<Guid, AccessInfo> _subscriptions = new();
+
+    public PackagingService()
+    {
+        // Seed with a couple of sample users and subscription info.
+        var user1 = Guid.Parse("00000000-0000-0000-0000-000000000001");
+        var user2 = Guid.Parse("00000000-0000-0000-0000-000000000002");
+
+        _subscriptions[user1] = new AccessInfo("Basic", 3);
+        _subscriptions[user2] = new AccessInfo("Premium", 10);
+    }
+
+    public AccessInfo GetAccessInfo(Guid userId)
+    {
+        return _subscriptions.TryGetValue(userId, out var info)
+            ? info
+            : new AccessInfo("Free", 1);
+    }
+
+    public bool Ping() => true;
+}

--- a/tests/DidarTask.Application.Tests/PackagingConnectionTests.cs
+++ b/tests/DidarTask.Application.Tests/PackagingConnectionTests.cs
@@ -1,0 +1,30 @@
+using System;
+using DidarTask.Application.Services;
+using Xunit;
+
+namespace DidarTask.Application.Tests;
+
+public class PackagingConnectionTests
+{
+    [Fact]
+    public void VerifyPackagingConnection_ReturnsTrue()
+    {
+        var packagingService = new PackagingService();
+        var applicationService = new ApplicationService(packagingService);
+
+        Assert.True(applicationService.VerifyPackagingConnection());
+    }
+
+    [Fact]
+    public void RequestAccessInfo_ReturnsExpectedSubscriptionLevel()
+    {
+        var packagingService = new PackagingService();
+        var applicationService = new ApplicationService(packagingService);
+
+        var userId = Guid.Parse("00000000-0000-0000-0000-000000000001");
+        var access = applicationService.RequestAccessInfo(userId);
+
+        Assert.Equal("Basic", access.SubscriptionLevel);
+        Assert.Equal(3, access.AllowedFeatures);
+    }
+}


### PR DESCRIPTION
## Summary
- add PackagingService and ApplicationService to demonstrate subscription-based access control
- include a ping-based connectivity check between services
- add unit tests verifying connection and access info retrieval

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68961b410f4c8331b7d0bd206d3e96a7