### PR TITLE
feat: add rollback mechanism across services

### DIFF
--- a/src/DidarTask.Application/Services/IApplicationService.cs
+++ b/src/DidarTask.Application/Services/IApplicationService.cs
@@ -1,0 +1,14 @@
+namespace DidarTask.Application.Services;
+
+/// <summary>
+/// Minimal interface exposing availability of the Application service. This allows
+/// other services to coordinate changes and roll them back if the application is
+/// unreachable.
+/// </summary>
+public interface IApplicationService
+{
+    /// <summary>
+    /// Returns true when the Application service is reachable.
+    /// </summary>
+    bool Ping();
+}

--- a/src/DidarTask.Application/Services/IPackagingService.cs
+++ b/src/DidarTask.Application/Services/IPackagingService.cs
@@ -14,6 +14,12 @@ public interface IPackagingService
     AccessInfo GetAccessInfo(Guid userId);
 
     /// <summary>
+    /// Attempts to change a user's subscription. Returns false and rolls back
+    /// when the Application service cannot be reached.
+    /// </summary>
+    bool TryChangeSubscription(Guid userId, AccessInfo newInfo, IApplicationService applicationService);
+
+    /// <summary>
     /// Returns true when the Packaging service is reachable.
     /// </summary>
     bool Ping();

--- a/src/DidarTask.Application/Services/TransactionCoordinator.cs
+++ b/src/DidarTask.Application/Services/TransactionCoordinator.cs
@@ -1,0 +1,31 @@
+using System;
+
+namespace DidarTask.Application.Services;
+
+/// <summary>
+/// Provides a very small coordination mechanism that applies a local change and
+/// verifies the remote service. If the verification fails or throws, the local
+/// change is rolled back using the supplied rollback action.
+/// </summary>
+public static class TransactionCoordinator
+{
+    public static bool Execute(Action apply, Func<bool> remoteCheck, Action rollback)
+    {
+        try
+        {
+            apply();
+            if (!remoteCheck())
+            {
+                rollback();
+                return false;
+            }
+
+            return true;
+        }
+        catch
+        {
+            rollback();
+            throw;
+        }
+    }
+}

--- a/tests/DidarTask.Application.Tests/PackagingConnectionTests.cs
+++ b/tests/DidarTask.Application.Tests/PackagingConnectionTests.cs
@@ -27,4 +27,37 @@ public class PackagingConnectionTests
         Assert.Equal("Basic", access.SubscriptionLevel);
         Assert.Equal(3, access.AllowedFeatures);
     }
+
+    [Fact]
+    public void ApplyBusinessChange_RollsBack_WhenPackagingUnavailable()
+    {
+        var packagingService = new PackagingService(isAvailable: false);
+        var applicationService = new ApplicationService(packagingService);
+
+        var result = applicationService.TryApplyBusinessChange(5);
+
+        Assert.False(result);
+        Assert.Equal(0, applicationService.BusinessState);
+    }
+
+    private class FailingApplicationService : IApplicationService
+    {
+        public bool Ping() => false;
+    }
+
+    [Fact]
+    public void ChangeSubscription_RollsBack_WhenApplicationUnavailable()
+    {
+        var packagingService = new PackagingService();
+        var failingApp = new FailingApplicationService();
+        var userId = Guid.Parse("00000000-0000-0000-0000-000000000001");
+        var newInfo = new AccessInfo("VIP", 20);
+
+        var result = packagingService.TryChangeSubscription(userId, newInfo, failingApp);
+
+        Assert.False(result);
+        var access = packagingService.GetAccessInfo(userId);
+        Assert.Equal("Basic", access.SubscriptionLevel);
+        Assert.Equal(3, access.AllowedFeatures);
+    }
 }


### PR DESCRIPTION
## Summary
- add a transaction coordinator to manage cross-service changes
- expose application service availability through a new interface
- rollback packaging or application changes if their counterpart is unavailable

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68961cf147d48331894848781dc2695f